### PR TITLE
Remove all links to IBP ICS pages

### DIFF
--- a/README-cn.md
+++ b/README-cn.md
@@ -174,10 +174,7 @@ cd ~/fabric-tools
 ## 部署到 IBM Cloud
 
 可以将区块链网络部署到 IBM Cloud。 
-可以使用 [IBM Blockchain Platform](https://console.bluemix.net/catalog/services/blockchain) 并在 `Starter Membership Plan` 下免费开始部署。  遵循[这些指示信息](https://ibm-blockchain.github.io/platform-deployment/) 将业务网络部署到 IBM Blockchain Platform。
-
-要将区块链网络部署为 kubernetes 集群，请遵循[此处](https://ibm-blockchain.github.io/setup/) 的指示信息。  该指南演示了如何在 IBM Cloud 上创建一个免费集群并部署您的业务网络。  这将提供要供应用程序使用的 composer rest 服务器的 IP 地址。
-
+可以使用 [IBM Blockchain Platform](https://console.bluemix.net/catalog/services/blockchain) 并在 `Starter Membership Plan` 下免费开始部署。  遵循[这些指示信息](https://console.bluemix.net/docs/services/blockchain/develop_starter.html#deploying-a-business-network) 将业务网络部署到 IBM Blockchain Platform。
 
 ## 附加资源
 * [Hyperledger Fabric 文档](http://hyperledger-fabric.readthedocs.io/en/latest/)

--- a/README.md
+++ b/README.md
@@ -177,10 +177,7 @@ This application demonstrates a basic idea of a decentralized energy network usi
 ## Deploy to IBM Cloud
 
 The blockchain network can be deployed to IBM Cloud. 
-You can use the [IBM Blockchain platform](https://console.bluemix.net/catalog/services/blockchain) and start for free under `Starter Membership Plan`.  Follow [these instructions](https://ibm-blockchain.github.io/platform-deployment/) to deploy the business network to IBM Blockchain platform.
-
-To deploy the Blockchain network as kubernetes cluster follow the instructions [here](https://ibm-blockchain.github.io/setup/).  The guide walks through creating a free cluster on IBM Cloud and deploying your business network.  This will provide the IP address for the composer rest server to be used by the application.
-
+You can use the [IBM Blockchain platform](https://console.bluemix.net/catalog/services/blockchain) and start for free under `Starter Membership Plan`.  Follow [these instructions](https://console.bluemix.net/docs/services/blockchain/develop_starter.html#deploying-a-business-network) to deploy the business network to IBM Blockchain platform.
 
 ## Additional Resources
 * [Hyperledger Fabric Docs](http://hyperledger-fabric.readthedocs.io/en/latest/)


### PR DESCRIPTION
The IBM Blockchain Platform team is removing the container service scripts and website located at these links:

https://github.com/IBM-Blockchain/ibm-container-service/
http://ibm-blockchain.github.io

This PR removes all references to these links.

I am the lead engineer of the IBM Blockchain Platform developer experience team; please feel free to reach out to me via Slack etc if you want to discuss.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>